### PR TITLE
Add real yml config parser

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -26,7 +26,7 @@ func actionMakeRequest(c *cli.Context) {
 	} else if len(c.Args()) > 1 {
 		// Read config file
 		filename := c.Args()[0]
-		config, err := config.FromYaml(filename)
+		requests, err := config.RequestsFromYaml(filename)
 		if err != nil {
 			fmt.Printf("%s\n", err)
 			os.Exit(-1)
@@ -34,7 +34,7 @@ func actionMakeRequest(c *cli.Context) {
 
 		// Find and make request
 		requestName := c.Args()[1]
-		requestConfig, ok := config.Requests[requestName]
+		requestConfig, ok := requests[requestName]
 		if ok {
 			fmt.Printf("%#v", requestConfig)
 		} else {

--- a/config/config.go
+++ b/config/config.go
@@ -1,41 +1,104 @@
 /*
-	Package config is responsible for reading and exposing configuration variables
+	Package config is responsible for reading and exposing request configuration variables
 */
 package config
 
 import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"reflect"
 )
 
 type config struct {
-	Globals  globals
-	Requests map[string]request
+	Globals  Request
+	Requests map[string]Request
 }
 
-type globals struct {
-	BaseUrl string "base_url"
-	Headers map[string]string
-}
-
-type request struct {
-	Path        string
+type Request struct {
+	BaseUrl     string "base_url"
+	BodyFormat  string "body_format"
 	Method      string
-	BodyFormat  string            "body_format"
+	Path        string
+	Url         string
 	Body        map[string]string // This should be an interface to respect yaml types!
+	Headers     map[string]string
 	QueryString map[string]string "query_str"
 }
 
 /*
-	parseYaml takes a path to the request yaml file and returns a map containing the
+	RequestsFromYaml takes a path to the request yaml file and returns a map containing the
 	the configuration for the requests defined in that file.
 */
-func FromYaml(filename string) (config config, err error) {
+func RequestsFromYaml(filename string) (map[string]Request, error) {
+	var config config
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return
+		return config.Requests, err
 	}
 
 	yaml.Unmarshal(data, &config)
-	return
+
+	for requestName, _ := range config.Requests {
+		config.Requests[requestName] = applyGlobals(config.Requests[requestName], config.Globals)
+		config.Requests[requestName] = mergeHeaders(config.Requests[requestName], config.Globals)
+		config.Requests[requestName] = setUrlFromBaseUrl(config.Requests[requestName])
+	}
+
+	return config.Requests, err
+}
+
+// Apply values from globals to every zero-valued field in request.
+func applyGlobals(request Request, globals Request) Request {
+	requestValue := reflect.ValueOf(&request).Elem()
+	globalsValue := reflect.ValueOf(&globals).Elem()
+
+	//Transverse all exported fields from Config struct
+	for i := 0; i < requestValue.NumField(); i++ {
+		requestField := requestValue.Field(i)
+		globalsField := globalsValue.Field(i)
+		newValue := firstNonZeroValue(requestField.Interface(), globalsField.Interface())
+
+		requestField.Set(newValue)
+	}
+
+	return request
+}
+
+// firstNonBlank returns ValueOf(defaulValue) if value is a zero-value.
+func firstNonZeroValue(value interface{}, defaultValue interface{}) reflect.Value {
+	var returnValue interface{}
+
+	switch value.(type) {
+	case string:
+		if value == "" {
+			returnValue = defaultValue
+		} else {
+			returnValue = value
+		}
+	case map[string]string:
+		if len(value.(map[string]string)) == 0 {
+			returnValue = defaultValue
+		} else {
+			returnValue = value
+		}
+	default:
+		panic("Type not supported")
+	}
+	return reflect.ValueOf(returnValue)
+}
+
+func setUrlFromBaseUrl(request Request) Request {
+	if request.Url == "" {
+		request.Url = request.BaseUrl + request.Path
+	}
+	return request
+}
+
+func mergeHeaders(request Request, globals Request) Request {
+	for headerName, headerValue := range globals.Headers {
+		if request.Headers[headerName] == "" {
+			request.Headers[headerName] = headerValue
+		}
+	}
+	return request
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,31 +5,61 @@ import (
 	"testing"
 )
 
-func TestFromYaml(t *testing.T) {
-	// Test file opening
-	notExistentFile := "./FileThatDoesNotExist"
-	_, err := FromYaml(notExistentFile)
-	expect.Error(t, err)
-
-	requestsFile := "./fixtures/yamlparser.yml"
-	requests, err := FromYaml(requestsFile)
+func readYaml(t *testing.T, filename string) map[string]Request {
+	requestsFile := filename
+	requests, err := RequestsFromYaml(requestsFile)
 	if err != nil {
 		t.Error("Yml parsing failed with error: %v", err)
 	}
+	return requests
+}
 
-	// Globals
-	expect.Equal(t, requests.Globals.BaseUrl, "https://example.com")
-	expect.Equal(t, requests.Globals.Headers["AUTHENTICATION_TOKEN"], "123456")
+func TestRequestsFromYamlParsesYamlFile(t *testing.T) {
+	// Test file opening
+	notExistentFile := "./FileThatDoesNotExist"
+	_, err := RequestsFromYaml(notExistentFile)
+	expect.Error(t, err)
+
+	requests := readYaml(t, "./fixtures/simple.yml")
 
 	// Requests
-	expect.Equal(t, len(requests.Requests), 2)
+	expect.Equal(t, len(requests), 3)
 
-	expect.Equal(t, requests.Requests["example_post"].Path, "/example_endpoint")
-	expect.Equal(t, requests.Requests["example_post"].Method, "POST")
-	expect.Equal(t, requests.Requests["example_post"].BodyFormat, "json")
+	expect.Equal(t, requests["example_post"].Path, "/example_endpoint")
+	expect.Equal(t, requests["example_post"].Method, "POST")
+	expect.Equal(t, requests["example_post"].BodyFormat, "json")
 
-	expect.Equal(t, requests.Requests["example_post"].Body["first_name"], "John")
-	expect.Equal(t, requests.Requests["example_post"].Body["last_name"], "Doe")
+	expect.Equal(t, requests["example_post"].Body["first_name"], "John")
+	expect.Equal(t, requests["example_post"].Body["last_name"], "Doe")
 
-	expect.Equal(t, requests.Requests["example_post"].QueryString["format"], "json")
+	expect.Equal(t, requests["example_post"].QueryString["format"], "json")
+}
+
+func TestRequestsFromYamlSetsConfigurationFromGlobals(t *testing.T) {
+	requests := readYaml(t, "./fixtures/simple.yml")
+	request := requests["example_post"]
+
+	expect.Equal(t, request.BaseUrl, "https://example.com")
+	expect.DeepEqual(t, request.Headers, map[string]string{"AUTHENTICATION_TOKEN": "123456"})
+}
+
+func TestRequestsFromYamlSetsUrlFromBaseUrlAndPath(t *testing.T) {
+	requests := readYaml(t, "./fixtures/simple.yml")
+	requestWithUrl := requests["example_get"]
+	requestWithoutUrl := requests["example_post"]
+
+	expect.Equal(t, requestWithUrl.Url, "https://test.example.com/example_endpoint_2")
+	expect.Equal(t, requestWithoutUrl.Url, "https://example.com/example_endpoint")
+}
+
+func TestHeadersAreMergedWithGlobalsHeaders(t *testing.T) {
+	requests := readYaml(t, "./fixtures/simple.yml")
+	requestWithNoAuthToken := requests["example_get"]
+	requestWithAuthToken := requests["override_auth_token"]
+
+	expect.Equal(t, requestWithNoAuthToken.Headers["Accept-Encoding"], "application/json")
+	expect.Equal(t, requestWithNoAuthToken.Headers["AUTHENTICATION_TOKEN"], "123456")
+
+	expect.Equal(t, requestWithAuthToken.Headers["Accept-Encoding"], "application/json")
+	expect.Equal(t, requestWithAuthToken.Headers["AUTHENTICATION_TOKEN"], "overriden!")
 }

--- a/config/fixtures/simple.yml
+++ b/config/fixtures/simple.yml
@@ -15,8 +15,15 @@ requests:
       format: json
 
   example_get: # yurl users_endpoint users
-    path: /example_endpoint_2
+    url: https://test.example.com/example_endpoint_2
     method: GET
     query_str:
       age: 30
       created_on: 30/02/1992
+    headers:
+      Accept-Encoding: application/json
+
+  override_auth_token:
+    headers:
+      AUTHENTICATION_TOKEN: overriden!
+      Accept-Encoding: application/json

--- a/requests/requests.go
+++ b/requests/requests.go
@@ -1,0 +1,22 @@
+/*
+	Package requests is responsible for making http requests based on a Config object.
+*/
+package requests
+
+import (
+	"github.com/eidge/yurl/config"
+	"net/http"
+)
+
+type Request struct{}
+
+var client = &http.Client{}
+
+func newRequest(config config.Request) (*http.Request, error) {
+	request, err := http.NewRequest("GET", config.Url, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return request, nil
+}

--- a/testing/expect/expect.go
+++ b/testing/expect/expect.go
@@ -1,11 +1,18 @@
 package expect
 
 import (
+	"reflect"
 	"testing"
 )
 
 func Equal(t *testing.T, actual interface{}, expected interface{}) {
 	if actual != expected {
+		t.Error("Expected %s, got %v", expected, actual)
+	}
+}
+
+func DeepEqual(t *testing.T, actual interface{}, expected interface{}) {
+	if !reflect.DeepEqual(actual, expected) {
 		t.Error("Expected %s, got %v", expected, actual)
 	}
 }

--- a/yurl_test.go
+++ b/yurl_test.go
@@ -46,7 +46,7 @@ func TestYurlWithNonExistantFile(t *testing.T) {
 }
 
 func TestYurlWithNonExistantRequest(t *testing.T) {
-	yurl := startYurl("config/fixtures/yamlparser.yml request_name")
+	yurl := startYurl("config/fixtures/simple.yml request_name")
 	defer yurl.Close()
 
 	match, _ := yurl.ExpectRegex("not found")
@@ -54,9 +54,9 @@ func TestYurlWithNonExistantRequest(t *testing.T) {
 }
 
 func TestYurlWithValidArguments(t *testing.T) {
-	yurl := startYurl("config/fixtures/yamlparser.yml example_post")
+	yurl := startYurl("config/fixtures/simple.yml example_post")
 	defer yurl.Close()
 
-	match, _ := yurl.ExpectRegex("config.request")
+	match, _ := yurl.ExpectRegex("config.Request") // FIXME: Placeholder
 	expect.Equal(t, match, true)
 }


### PR DESCRIPTION
Apply globals variables to zero-valued variables in every request.
Merge globals headers with each requests headers (This is the only map that gets merged instead of replaced if empty)
Use BaseUrl+Path for the Url if Url is empty

`config.RequestsFromYaml` now returns a map of requests instead of the `config` struct. The globals `Request` is useless if every request is parsed and merged with the globals data inside the config pkg.
